### PR TITLE
Determine site title based on shortest visit url

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -83,6 +83,7 @@ requirejs(['async', 'node/interval-tree/IntervalTree', 'node/alike/main'],
                         Array.prototype.push.apply(visits, items.map(function (item) {
                             return {
                                 url: result.url,
+                                title: result.title,
                                 visitTime: item.visitTime
                             };
                         }));
@@ -218,6 +219,7 @@ requirejs(['async', 'node/interval-tree/IntervalTree', 'node/alike/main'],
                     var date = new Date(item.visitTime);
                     var obj = dateToObj(date);
                     obj.url = item.url;
+                    obj.title = item.title;
                     obj.visitTime = item.visitTime;
                     var host = getHost(item.url);
                     if (!sites.hasOwnProperty(host)) {
@@ -280,6 +282,19 @@ requirejs(['async', 'node/interval-tree/IntervalTree', 'node/alike/main'],
                     return commonEvents;
                 }
 
+                function titleForHost(host) {
+                    let site = sites[host];
+                    var title = site[0].title;
+                    var shortestUrlLength = site[0].url.length;
+                    for (var i = 1; i < site.length; i++) {
+                        if (site[i].url.length < shortestUrlLength) {
+                            shortestUrlLength = site[i].url.length;
+                            title = site[i].title;
+                        }
+                    }
+                    return title;
+                }
+
                 function getLinks(callback) {
                     var testObj = dateToObj(new Date(Date.now()));
                     var currentEvents = itree.search(Date.now() / 10000); // convert to 10 second resolution
@@ -313,6 +328,7 @@ requirejs(['async', 'node/interval-tree/IntervalTree', 'node/alike/main'],
                         }
                         results.push({
                             host: host,
+                            title: titleForHost(host),
                             score: score,
                             commonEvents: commonEvents
                         });

--- a/js/main.js
+++ b/js/main.js
@@ -35,7 +35,7 @@ function renderLinks(response) {
             colorBars += '<div class="colorBar" style="background-color: rgb(' + colors[k].r + ',' + colors[k].g + ',' + colors[k].b + ')"></div>';
         }
 
-        var title = response[i].host;//response[i].title != '' ? response[i].title : response[i].host;
+        var title = response[i].title || response[i].host;
 
         var html = '<li class="link-item">' +
             '<a href="http://' + response[i].host + '">' +


### PR DESCRIPTION
Display site titles on the new tab page, determined by the title of the history visit with the shortest url. This works well for some sites where the url usually visits the main page, but if the user hasn't visited the home page recently, then the resulting title is not as useful. 

![image](https://cloud.githubusercontent.com/assets/376616/9025379/70be48a2-38b7-11e5-8348-c1eceeab49c6.png)
